### PR TITLE
Add compress option (and make default FALSE)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2cl
-Version: 0.5-3
-Date: 2017-06-05
+Version: 0.5-4
+Date: 2017-06-07
 Title: Command-Line Interface for R/qtl2
 Description: Support for a command-line interface for R/qtl2.
 Author: Karl W Broman

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## qtl2cl 0.5-4 (2017-06-07)
+
+### New features
+
+- Add argument `compress` for indicating whether to save compressed
+  RDS files or not; default is *not* to compress (so bigger files, but
+  faster to write/read).
+
+
 ## qtl2cl 0.5-3 (2017-06-05)
 
 ### Minor changes

--- a/R/cross2rds.R
+++ b/R/cross2rds.R
@@ -8,6 +8,7 @@
 #' data files, in which case the contents are unzipped to a temporary
 #' directory and then read.
 #' @param output_file Character string with path to RDS file for output
+#' @param compress If TRUE, save a compressed RDS file (smaller but slower).
 #'
 #' @importFrom qtl2geno read_cross2
 #' @export
@@ -17,7 +18,7 @@
 #'                      "blob/master/B6BTBR/b6btbr.zip")
 #' \dontrun{cross2rds(input_file, "b6btbr.rds")}
 cross2rds <-
-    function(input_file, output_file)
+    function(input_file, output_file, compress=FALSE)
 {
-    saveRDS( qtl2geno::read_cross2(input_file), file=output_file )
+    saveRDS( qtl2geno::read_cross2(input_file), file=output_file, compress=compress )
 }

--- a/R/run_calcgenoprob.R
+++ b/R/run_calcgenoprob.R
@@ -21,6 +21,7 @@
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
 #' Alternatively, this can be links to a set of cluster sockets, as
 #' produced by \code{\link[parallel]{makeCluster}}.
+#' @param compress If TRUE, save compressed RDS files (smaller but slower).
 #'
 #' @importFrom qtl2geno calc_genoprob insert_pseudomarkers
 #' @export
@@ -33,7 +34,7 @@
 run_calcgenoprob <-
     function(cross_file, output_file, map_file=NULL, step=0, off_end=0, stepwidth=c("fixed", "max"),
          error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
-         cores=1)
+         cores=1, compress=FALSE)
 {
     stepwidth <- match.arg(stepwidth)
     map_function <- match.arg(map_function)
@@ -42,10 +43,10 @@ run_calcgenoprob <-
     map <- qtl2geno::insert_pseudomarkers(cross$gmap, step=step, off_end=off_end, stepwidth=stepwidth)
 
     if(!is.null(map_file) && map_file != "")
-        saveRDS( map, file=map_file )
+        saveRDS( map, file=map_file, compress=compress )
 
     saveRDS( qtl2geno::calc_genoprob(cross=cross, map=map,
                                      error_prob=error_prob, map_function=map_function,
                                      lowmem=FALSE, quiet=TRUE, cores=cores),
-            file=output_file )
+            file=output_file, compress=compress )
 }

--- a/R/run_calckinship.R
+++ b/R/run_calckinship.R
@@ -19,6 +19,7 @@
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
 #' Alternatively, this can be links to a set of cluster sockets, as
 #' produced by \code{\link[parallel]{makeCluster}}.
+#' @param compress If TRUE, save a compressed RDS file (smaller but slower).
 #'
 #' @importFrom qtl2geno calc_kinship
 #' @export
@@ -32,12 +33,12 @@
 run_calckinship <-
     function(input_file, output_file, type=c("overall", "loco", "chr"),
              omit_x=FALSE,
-             use_allele_probs=TRUE, cores=1)
+             use_allele_probs=TRUE, cores=1, compress=FALSE)
 {
     type <- match.arg(type)
 
     saveRDS( qtl2geno::calc_kinship( readRDS(input_file), type=type,
                                     omit_x=omit_x, use_allele_probs=use_allele_probs,
                                     quiet=TRUE, cores=cores),
-            file=output_file)
+            file=output_file, compress=compress )
 }

--- a/R/run_getXcovar.R
+++ b/R/run_getXcovar.R
@@ -4,6 +4,7 @@
 #'
 #' @param input_file Input RDS file for cross
 #' @param output_file Output RDS file for X chromosome covariates
+#' @param compress If TRUE, save a compressed RDS file (smaller but slower).
 #'
 #' @importFrom qtl2geno get_x_covar
 #' @export
@@ -14,7 +15,7 @@
 #' \dontrun{cross2rds(input_file, "b6btbr.rds")}
 #' \dontrun{run_getXcovar("b6btbr.rds", "b6btbr_xcovar.rds")}
 run_getXcovar <-
-    function(input_file, output_file)
+    function(input_file, output_file, compress=FALSE)
 {
-    saveRDS( qtl2geno::get_x_covar( readRDS(input_file) ), file=output_file )
+    saveRDS( qtl2geno::get_x_covar( readRDS(input_file) ), file=output_file, compress=compress )
 }

--- a/R/run_gp2ap.R
+++ b/R/run_gp2ap.R
@@ -9,6 +9,7 @@
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
 #' Alternatively, this can be links to a set of cluster sockets, as
 #' produced by \code{\link[parallel]{makeCluster}}.
+#' @param compress If TRUE, save a compressed RDS file (smaller but slower).
 #'
 #' @importFrom qtl2geno genoprob_to_alleleprob
 #' @export
@@ -20,9 +21,9 @@
 #' \dontrun{run_calcgenoprob("b6btbr.rds", "b6btbr_probs.rds")}
 #' \dontrun{run_gp2ap("b6btbr_probs.rds", "b6btbr_aprobs.rds")}
 run_gp2ap <-
-    function(input_file, output_file, cores=1)
+    function(input_file, output_file, cores=1, compress=FALSE)
 {
     saveRDS( qtl2geno::genoprob_to_alleleprob( readRDS(input_file),
                                               quiet=TRUE, cores=cores),
-            file=output_file)
+            file=output_file, compress=compress)
 }

--- a/R/run_scan1.R
+++ b/R/run_scan1.R
@@ -13,6 +13,7 @@
 #' @param weights_file Optional file containing covariates
 #' @param reml If TRUE, use REML; otherwise, use maximum likelihood
 #' @param cores Number of CPU cores to use
+#' @param compress If TRUE, save a compressed RDS file (smaller but slower).
 #'
 #' @importFrom qtl2scan scan1
 #' @importFrom qtl2convert scan_qtl2_to_qtl
@@ -28,7 +29,8 @@ run_scan1 <-
              intcovar_file=NULL,
              weights_file=NULL,
              reml=TRUE,
-             cores=1)
+             cores=1,
+             compress=FALSE)
 {
     # read file if not NULL; otherwise pass along the NULL
     read_file0 <-
@@ -66,6 +68,6 @@ run_scan1 <-
         cat(jsonlite::toJSON(tab), "\n")
     }
     else {
-        saveRDS(result, file=output_file)
+        saveRDS(result, file=output_file, compress=compress)
     }
 }

--- a/inst/example/example_script.sh
+++ b/inst/example/example_script.sh
@@ -1,3 +1,5 @@
+# need to add scripts directory in the installed package to PATH
+#    use system.file("scripts", package="qtl2cl") to find the directory
 export PATH=$PATH:~/Rlibs/qtl2cl/scripts/
 
 qtl2cl --cross2rds -i ~/Rlibs/qtl2geno/extdata/iron.zip -o iron.rds

--- a/inst/scripts/qtl2cl
+++ b/inst/scripts/qtl2cl
@@ -20,6 +20,8 @@ option_list <- list(
                 help="Input file [not used with --scan1]"),
     make_option(c("-o", "--output"), action="store", type="character",
                 help="Output file"),
+    make_option("--compress", action="store_true", type="logical", default=FALSE,
+                  help="Save compressed RDS files"),
 
     # for calc_genoprob
     make_option("--step", action="store", type="double", default=0,
@@ -91,7 +93,7 @@ if(opt$cross2rds) {
     if(is.null(opt$output) || opt$output == "")
         stop("Provide output file name (RDS file)")
 
-    qtl2cl::cross2rds(opt$input, opt$output)
+    qtl2cl::cross2rds(opt$input, opt$output, compress=opt$compress)
 
 } else if(opt$get_x_covar) {
 
@@ -100,7 +102,7 @@ if(opt$cross2rds) {
     if(is.null(opt$output) || opt$output == "")
         stop("Provide output file name (RDS file)")
 
-    qtl2cl::run_getXcovar(opt$input, opt$output)
+    qtl2cl::run_getXcovar(opt$input, opt$output, compress=opt$compress)
 
 } else if(opt$calc_genoprob) {
 
@@ -112,7 +114,8 @@ if(opt$cross2rds) {
     qtl2cl::run_calcgenoprob(opt$input, opt$output, map_file=opt$map_file,
                              step=opt$step, off_end=opt$off_end,
                              stepwidth=opt$stepwidth, error_prob=opt$error_prob,
-                             map_function=opt$map_function, cores=opt$cores)
+                             map_function=opt$map_function, cores=opt$cores,
+                             compress=opt$compress)
 
 } else if(opt$genoprob_to_alleleprob) {
 
@@ -121,7 +124,7 @@ if(opt$cross2rds) {
     if(is.null(opt$output) || opt$output == "")
         stop("Provide output file name (RDS file)")
 
-    qtl2cl::run_gp2ap(opt$input, opt$output, cores=opt$cores)
+    qtl2cl::run_gp2ap(opt$input, opt$output, cores=opt$cores, compress=opt$compress)
 
 } else if(opt$calc_kinship) {
 
@@ -132,7 +135,7 @@ if(opt$cross2rds) {
 
     qtl2cl::run_calckinship(opt$input, opt$output, type=opt$type,
                             omit_x=opt$omit_x, use_allele_probs=opt$use_allele_probs,
-                            cores=opt$cores)
+                            cores=opt$cores, compress=opt$compress)
 
 } else if(opt$scan1) {
 
@@ -149,6 +152,6 @@ if(opt$cross2rds) {
               kinship_file=opt$kinship,
               addcovar_file=opt$addcovar, Xcovar_file=opt$Xcovar,
               intcovar_file=opt$intcovar, weights_file=opt$weights,
-              reml=opt$reml, cores=opt$cores)
+              reml=opt$reml, cores=opt$cores, compress=opt$compress)
 
 }

--- a/inst/scripts/qtl2cl
+++ b/inst/scripts/qtl2cl
@@ -42,8 +42,6 @@ option_list <- list(
                 help="For --calc_kinship, if TRUE, use only autosomes"),
     make_option("--use_allele_probs", action="store", type="logical", default=TRUE,
                 help="For --calc_kinship, if TRUE, first convert genotype probabilities to allele dosages"),
-    make_option("--normalize", action="store", type="logical", default=FALSE,
-                help="For --calc_kinship, if TRUE, divide the kinship matrix by a normalizing constant"),
 
     # for scan1
     make_option("--genoprobs", action="store", type="character", default="",
@@ -134,7 +132,7 @@ if(opt$cross2rds) {
 
     qtl2cl::run_calckinship(opt$input, opt$output, type=opt$type,
                             omit_x=opt$omit_x, use_allele_probs=opt$use_allele_probs,
-                            normalize=opt$normalize, cores=opt$cores)
+                            cores=opt$cores)
 
 } else if(opt$scan1) {
 

--- a/man/cross2rds.Rd
+++ b/man/cross2rds.Rd
@@ -4,7 +4,7 @@
 \alias{cross2rds}
 \title{Read cross and save as rds}
 \usage{
-cross2rds(input_file, output_file)
+cross2rds(input_file, output_file, compress = FALSE)
 }
 \arguments{
 \item{input_file}{Character string with path to the
@@ -14,6 +14,8 @@ data files, in which case the contents are unzipped to a temporary
 directory and then read.}
 
 \item{output_file}{Character string with path to RDS file for output}
+
+\item{compress}{If TRUE, save a compressed RDS file (smaller but slower).}
 }
 \description{
 Read cross files and save as rds

--- a/man/run_calcgenoprob.Rd
+++ b/man/run_calcgenoprob.Rd
@@ -6,7 +6,8 @@
 \usage{
 run_calcgenoprob(cross_file, output_file, map_file = NULL, step = 0,
   off_end = 0, stepwidth = c("fixed", "max"), error_prob = 0.0001,
-  map_function = c("haldane", "kosambi", "c-f", "morgan"), cores = 1)
+  map_function = c("haldane", "kosambi", "c-f", "morgan"), cores = 1,
+  compress = FALSE)
 }
 \arguments{
 \item{cross_file}{Character string with path to RDS file containing cross}
@@ -36,6 +37,8 @@ use to convert genetic distances to recombination fractions.}
 (If \code{0}, use \code{\link[parallel]{detectCores}}.)
 Alternatively, this can be links to a set of cluster sockets, as
 produced by \code{\link[parallel]{makeCluster}}.}
+
+\item{compress}{If TRUE, save compressed RDS files (smaller but slower).}
 }
 \description{
 Run calc_genoprob and save result to rds

--- a/man/run_calckinship.Rd
+++ b/man/run_calckinship.Rd
@@ -5,7 +5,7 @@
 \title{Calculate kinship matrix}
 \usage{
 run_calckinship(input_file, output_file, type = c("overall", "loco", "chr"),
-  omit_x = FALSE, use_allele_probs = TRUE, cores = 1)
+  omit_x = FALSE, use_allele_probs = TRUE, cores = 1, compress = FALSE)
 }
 \arguments{
 \item{input_file}{Input RDS file containing genotype or allele probabilities}
@@ -29,6 +29,8 @@ probabilities.}
 (If \code{0}, use \code{\link[parallel]{detectCores}}.)
 Alternatively, this can be links to a set of cluster sockets, as
 produced by \code{\link[parallel]{makeCluster}}.}
+
+\item{compress}{If TRUE, save a compressed RDS file (smaller but slower).}
 }
 \description{
 Calculate genetic similarity among individuals (kinship matrix)

--- a/man/run_getXcovar.Rd
+++ b/man/run_getXcovar.Rd
@@ -4,12 +4,14 @@
 \alias{run_getXcovar}
 \title{Get X covariates and write to file}
 \usage{
-run_getXcovar(input_file, output_file)
+run_getXcovar(input_file, output_file, compress = FALSE)
 }
 \arguments{
 \item{input_file}{Input RDS file for cross}
 
 \item{output_file}{Output RDS file for X chromosome covariates}
+
+\item{compress}{If TRUE, save a compressed RDS file (smaller but slower).}
 }
 \description{
 Read cross from RDS file, determine X chromosome covariates, and write to another RDS file.

--- a/man/run_gp2ap.Rd
+++ b/man/run_gp2ap.Rd
@@ -4,7 +4,7 @@
 \alias{run_gp2ap}
 \title{Run genoprob_to_alleleprob}
 \usage{
-run_gp2ap(input_file, output_file, cores = 1)
+run_gp2ap(input_file, output_file, cores = 1, compress = FALSE)
 }
 \arguments{
 \item{input_file}{Name of input file (should be RDS)}
@@ -15,6 +15,8 @@ run_gp2ap(input_file, output_file, cores = 1)
 (If \code{0}, use \code{\link[parallel]{detectCores}}.)
 Alternatively, this can be links to a set of cluster sockets, as
 produced by \code{\link[parallel]{makeCluster}}.}
+
+\item{compress}{If TRUE, save a compressed RDS file (smaller but slower).}
 }
 \description{
 Read in genotype probabilities, convert them to allele

--- a/man/run_scan1.Rd
+++ b/man/run_scan1.Rd
@@ -6,7 +6,8 @@
 \usage{
 run_scan1(genoprobs_file, pheno_file, output_file = NULL, map_file = NULL,
   kinship_file = NULL, addcovar_file = NULL, Xcovar_file = NULL,
-  intcovar_file = NULL, weights_file = NULL, reml = TRUE, cores = 1)
+  intcovar_file = NULL, weights_file = NULL, reml = TRUE, cores = 1,
+  compress = FALSE)
 }
 \arguments{
 \item{genoprobs_file}{Name of file with genotype probabilities}
@@ -30,6 +31,8 @@ run_scan1(genoprobs_file, pheno_file, output_file = NULL, map_file = NULL,
 \item{reml}{If TRUE, use REML; otherwise, use maximum likelihood}
 
 \item{cores}{Number of CPU cores to use}
+
+\item{compress}{If TRUE, save a compressed RDS file (smaller but slower).}
 }
 \description{
 Read in a bunch of data and then run \code{\link[qtl2scan]{scan1}}.


### PR DESCRIPTION
- When saving RDS files, the default is to save them in a compressed format. This can be slow for big files (though it does save space). Added `--compress` option in [qtl2cl](https://github.com/rqtl/qtl2cl), and made the default that RDS files won't be compressed.